### PR TITLE
Fix compilation on GHC 7.2.1

### DIFF
--- a/language-haskell-extract.cabal
+++ b/language-haskell-extract.cabal
@@ -52,7 +52,7 @@ author: Oscar Finnsson & Emil Nordling
 library
   hs-source-dirs: src
   exposed-modules: Language.Haskell.Extract
-  build-depends: base >= 4 && < 5, haskell98, regex-posix, haskell-src-exts, template-haskell
+  build-depends: base >= 4 && < 5, regex-posix, haskell-src-exts, template-haskell
 
 source-repository head
   type:     git

--- a/src/Language/Haskell/Extract.hs
+++ b/src/Language/Haskell/Extract.hs
@@ -8,7 +8,7 @@ import Language.Haskell.Exts.Parser
 import Language.Haskell.Exts (parseFileContentsWithMode)
 import Language.Haskell.Exts.Syntax
 import Text.Regex.Posix
-import Maybe
+import Data.Maybe
 import Data.List
 import Language.Haskell.Exts.Extension
 


### PR DESCRIPTION
From GHC 7.2.1 on it is no longer possible to use the `haskell98`
package together with the `base` package. This conflict is resolved by
removing the dependancy on `haskell98`.
