### PR TITLE
Set version lower bound on haskell-src-exts

### DIFF
--- a/language-haskell-extract.cabal
+++ b/language-haskell-extract.cabal
@@ -52,7 +52,7 @@ author: Oscar Finnsson & Emil Nordling
 library
   hs-source-dirs: src
   exposed-modules: Language.Haskell.Extract
-  build-depends: base >= 4 && < 5, regex-posix, haskell-src-exts, template-haskell
+  build-depends: base >= 4 && < 5, regex-posix, haskell-src-exts >= 1.8.0, template-haskell
 
 source-repository head
   type:     git


### PR DESCRIPTION
Needed since we rely on knownExtensions which was apparently introduced in 1.8.0
