### PR TITLE
Use AST parsing instead of reading first lexemas on every line.

### DIFF
--- a/language-haskell-extract.cabal
+++ b/language-haskell-extract.cabal
@@ -1,6 +1,6 @@
 name: language-haskell-extract
 version: 0.2.3
-cabal-version: >=1.6
+cabal-version: >=1.8
 build-type: Simple
 license: BSD3
 license-file: "BSD3.txt"
@@ -53,7 +53,13 @@ library
   ghc-options: -Wall
   hs-source-dirs: src
   exposed-modules: Language.Haskell.Extract
-  build-depends: base >= 4 && < 5, regex-posix, template-haskell
+  build-depends: base >= 4 && < 5, haskell-src-exts, regex-posix, template-haskell
+
+Test-Suite TestExtract
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: tests
+  main-is:        TestExtract.hs
+  build-depends: base, language-haskell-extract, test-framework, test-framework-hunit, HUnit 
 
 source-repository head
   type:     git

--- a/src/Language/Haskell/Extract.hs
+++ b/src/Language/Haskell/Extract.hs
@@ -3,15 +3,37 @@ module Language.Haskell.Extract (
   functionExtractorMap,
   locationModule
 ) where
-import Language.Haskell.TH
-import Text.Regex.Posix
+
 import Data.List
+import Data.Maybe
+import Language.Haskell.Exts.Annotated(
+    Decl(..), Extension(..), Match(..), Module(..), Name(..), Pat(..),
+    SrcSpanInfo, KnownExtension(..), fromParseResult, parseFileWithExts)
+import Language.Haskell.TH
+import Text.Regex.Posix ((=~))
+
+defaultExtensions :: [Extension]
+defaultExtensions = [EnableExtension TemplateHaskell]
 
 extractAllFunctions :: String -> Q [String]
 extractAllFunctions pattern =
   do loc <- location
-     file <- runIO $ readFile $ loc_filename loc
-     return $ nub $ filter (=~pattern) $ map fst $ concat $ map lex $ lines file
+     parseResult <- runIO $ parseFileWithExts defaultExtensions $ loc_filename loc
+     return $ nub $ filter (=~pattern) $ mapMaybe unwrapDeclNames
+         $ getDecls $ fromParseResult parseResult
+  where
+  getDecls (Module _ _ _ _ decls) = decls
+  getDecls _ = []
+  unwrapDeclNames :: Decl SrcSpanInfo -> Maybe String
+  unwrapDeclNames (FunBind _ []) = Nothing
+  unwrapDeclNames (FunBind _ (m:_)) = Just (fromMatch m)
+  unwrapDeclNames (PatBind _ (PVar _ name) _ _) = Just $ fromName name
+  unwrapDeclNames _ = Nothing
+  fromName (Ident _ name) = name
+  fromName (Symbol _ name) = name
+  fromMatch (Language.Haskell.Exts.Annotated.Match _ name _ _ _) = fromName name
+  fromMatch (Language.Haskell.Exts.Annotated.InfixMatch _ _ name _ _ _) = fromName name
+
 
 -- | Extract the names and functions from the module where this function is called.
 -- 

--- a/tests/Language/Haskell/ExtensionTest.hs
+++ b/tests/Language/Haskell/ExtensionTest.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE MagicHash #-}
+module Language.Haskell.ExtensionTest where
+
+import Test.HUnit
+
+import Language.Haskell.Extract 
+
+extensionTest = "magicConstant#" @=? fst (head $(functionExtractor "^magic"))
+
+-- Verifying that declared language extensions do not cause parsing problems.
+magicConstant# = 57

--- a/tests/Language/Haskell/LocationTest.hs
+++ b/tests/Language/Haskell/LocationTest.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Language.Haskell.LocationTest where
+
+import Test.HUnit
+
+import Language.Haskell.Extract 
+
+locationTest = "Language.Haskell.LocationTest" @=? $(locationModule)

--- a/tests/TestExtract.hs
+++ b/tests/TestExtract.hs
@@ -1,11 +1,13 @@
 {-# OPTIONS_GHC -XTemplateHaskell #-}
-module Language.Haskell.ExtractTest where
+module Main where
 
 import Test.Framework (defaultMain, testGroup)
 import Test.Framework.Providers.HUnit
 import Test.HUnit
 
 import Language.Haskell.Extract 
+import Language.Haskell.LocationTest
+import Language.Haskell.ExtensionTest
 
 main = defaultMain groupsOfTest
 
@@ -16,20 +18,23 @@ groupsOfTest = [
           testCase "third test" thirdTest,
           testCase "typeclassTest" typeclassTest,
           testCase "secondTypeclassTest" secondTypeclassTest,
-          testCase "thirdTypeclassTest" thirdTypeclassTest
+          testCase "thirdTypeclassTest" thirdTypeclassTest,
+          testCase "extractAllFunctionsTest" extractAllFunctionsTest,
+          testCase "locationTest" locationTest,
+          testCase "extensionTest" extensionTest
           ]
         ]
 
 firstTest = "firstTest" @=? fst (head  $(functionExtractor "^first"))
 
-secondTest = "Language.Haskell.ExtractTest" @=? $(locationModule)
+secondTest = "Main" @=? $(locationModule)
 
 thirdTest = snd (head $(functionExtractor "thirdFunction")) @=? "hej"
 
-thirdFunction = "hej"
-
-
-
+-- The second line wouold not work if the file is parsed by calling lex on every line.
+thirdFunction = "hej" ++
+  tcBlah
+  where tcBlah = ""
 
 typeclassTest =
   do let expected = "thirdFunctionhej"
@@ -37,7 +42,6 @@ typeclassTest =
          res = $(functionExtractorMap "thirdFunction" [| \n f -> n ++ f |])
          actual = head res
      expected @=? actual
-
 
 secondTypeclassTest =
   do let expected = ["45", "88.8", "\"hej\""]
@@ -49,8 +53,23 @@ thirdTypeclassTest =
          actual = length $(functionExtractor "functionWithArgument")
      expected @=? actual
 
+extractAllFunctionsTest =
+  do let expected = 3
+         actual = length $(functionExtractor "WithArgument$")
+     expected @=? actual
+
+-- Functions for extractAllFunctionsTest. They must have the same type signature.
 functionWithArgument xs = "hej" ++ xs
 
+fooWithArgument xs = "bye" ++ xs
+
+barWithArgument xs = tcTest ++ xs
+  where tcTest = "test"
+
+-- Constructors and data statements will be ignored by function extractor.
+data DataTypeWithArgument = ConstructorWithArgument Int | AnotherWithArgument String
+
+-- Functions for testing functionExtractorMap.
 tcInt :: Integer
 tcInt = 45
 
@@ -59,3 +78,9 @@ tcDouble = 88.8
 
 tcString :: String
 tcString = "hej"
+
+-- Making sure that commented code is not a problem.
+{-
+tcFoo :: String
+tcFoo = "hej"
+-}


### PR DESCRIPTION
Move tests to a cabal test suite.
Add tests to verify that previously broken cases are now fixed.
